### PR TITLE
feat: add total_out capability

### DIFF
--- a/.homeycompose/capabilities/meter_power_out.json
+++ b/.homeycompose/capabilities/meter_power_out.json
@@ -1,0 +1,14 @@
+{
+  "type": "number",
+  "title": {
+    "en": "Power Meter Out"
+  },
+  "uiComponent": "sensor",
+  "getable": true,
+  "setable": false,
+  "insights": true,
+  "units": {
+    "en": "kWh"
+  },
+  "icon": "assets/icons/capabilities/power_meter.svg"
+}

--- a/app.json
+++ b/app.json
@@ -1740,6 +1740,20 @@
       },
       "icon": "assets/icons/capabilities/power_meter.svg"
     },
+    "meter_power_out": {
+      "type": "number",
+      "title": {
+        "en": "Power Meter Out"
+      },
+      "uiComponent": "sensor",
+      "getable": true,
+      "setable": false,
+      "insights": true,
+      "units": {
+        "en": "kWh"
+      },
+      "icon": "assets/icons/capabilities/power_meter.svg"
+    },
     "multiplesockets": {
       "type": "boolean",
       "title": {

--- a/lib/sensor.js
+++ b/lib/sensor.js
@@ -25,7 +25,7 @@ const WiredSensorCapabilities = {
                 caption: 'Temperature ({sensor})',
                 capability: 'measure_temperature.{sensor}',
                 value_converter: null,
-                units: {default: 'C', units_field: 'TempUnit', units_template: '°{value}'}
+                units: { default: 'C', units_field: 'TempUnit', units_template: '°{value}' }
             },
         ],
         'Humidity': [
@@ -34,7 +34,7 @@ const WiredSensorCapabilities = {
                 caption: 'Humidity ({sensor})',
                 capability: 'measure_humidity.{sensor}',
                 value_converter: null,
-                units: {default: '%', units_field: null, units_template: '{value}'}
+                units: { default: '%', units_field: null, units_template: '{value}' }
             },
         ],
         'DewPoint': [
@@ -43,7 +43,7 @@ const WiredSensorCapabilities = {
                 caption: 'Dew point ({sensor})',
                 capability: 'measure_temperature.dew_point.{sensor}',
                 value_converter: null,
-                units: {default: 'C', units_field: 'TempUnit', units_template: '°{value}'}
+                units: { default: 'C', units_field: 'TempUnit', units_template: '°{value}' }
             },
         ],
         'Pressure': [
@@ -52,7 +52,7 @@ const WiredSensorCapabilities = {
                 caption: 'Pressure ({sensor})',
                 capability: 'measure_pressure.{sensor}',
                 value_converter: null,
-                units: {default: 'hPa', units_field: 'PressureUnit', units_template: '{value}'}
+                units: { default: 'hPa', units_field: 'PressureUnit', units_template: '{value}' }
             },
         ],
         'CarbonDioxide': [
@@ -61,7 +61,7 @@ const WiredSensorCapabilities = {
                 caption: 'Carbon dioxide ({sensor})',
                 capability: 'measure_co2.{sensor}',
                 value_converter: null,
-                units: {default: 'ppm', units_field: null, units_template: '{value}'}
+                units: { default: 'ppm', units_field: null, units_template: '{value}' }
             },
         ],
         'Illuminance': [
@@ -70,7 +70,7 @@ const WiredSensorCapabilities = {
                 caption: 'Illuminance ({sensor})',
                 capability: 'measure_luminance.{sensor}',
                 value_converter: null,
-                units: {default: 'lx', units_field: null, units_template: '{value}'}
+                units: { default: 'lx', units_field: null, units_template: '{value}' }
             },
         ],
         'CF1': [
@@ -79,7 +79,7 @@ const WiredSensorCapabilities = {
                 caption: 'CF1 ({sensor})',
                 capability: 'measure_particulate_matter.cf1.{sensor}',
                 value_converter: null,
-                units: {default: 'µg/m³', units_field: null, units_template: '{value}'}
+                units: { default: 'µg/m³', units_field: null, units_template: '{value}' }
             },
         ],
         'CF2.5': [
@@ -88,7 +88,7 @@ const WiredSensorCapabilities = {
                 caption: 'CF2.5 ({sensor})',
                 capability: 'measure_particulate_matter.cf2_5.{sensor}',
                 value_converter: null,
-                units: {default: 'µg/m³', units_field: null, units_template: '{value}'}
+                units: { default: 'µg/m³', units_field: null, units_template: '{value}' }
             },
         ],
         'CF10': [
@@ -97,7 +97,7 @@ const WiredSensorCapabilities = {
                 caption: 'CF10 ({sensor})',
                 capability: 'measure_particulate_matter.cf10.{sensor}',
                 value_converter: null,
-                units: {default: 'µg/m³', units_field: null, units_template: '{value}'}
+                units: { default: 'µg/m³', units_field: null, units_template: '{value}' }
             },
         ],
         'PM1': [
@@ -106,7 +106,7 @@ const WiredSensorCapabilities = {
                 caption: 'PM1 ({sensor})',
                 capability: 'measure_particulate_matter.pm1.{sensor}',
                 value_converter: null,
-                units: {default: 'ppd', units_field: null, units_template: '{value}'}
+                units: { default: 'ppd', units_field: null, units_template: '{value}' }
             },
         ],
         'PM2.5': [
@@ -115,7 +115,7 @@ const WiredSensorCapabilities = {
                 caption: 'PM2.5 ({sensor})',
                 capability: 'measure_particulate_matter.pm2_5.{sensor}',
                 value_converter: null,
-                units: {default: 'ppd', units_field: null, units_template: '{value}'}
+                units: { default: 'ppd', units_field: null, units_template: '{value}' }
             },
         ],
         'PM10': [
@@ -124,7 +124,7 @@ const WiredSensorCapabilities = {
                 caption: 'PM10 ({sensor})',
                 capability: 'measure_particulate_matter.pm10.{sensor}',
                 value_converter: null,
-                units: {default: 'ppd', units_field: null, units_template: '{value}'}
+                units: { default: 'ppd', units_field: null, units_template: '{value}' }
             },
         ],
         'PB0.3': [
@@ -133,7 +133,7 @@ const WiredSensorCapabilities = {
                 caption: 'PB0.3 ({sensor})',
                 capability: 'measure_particulate_matter.pb0_3.{sensor}',
                 value_converter: null,
-                units: {default: 'ppd', units_field: null, units_template: '{value}'}
+                units: { default: 'ppd', units_field: null, units_template: '{value}' }
             },
         ],
         'PB0.5': [
@@ -142,7 +142,7 @@ const WiredSensorCapabilities = {
                 caption: 'PB0.5 ({sensor})',
                 capability: 'measure_particulate_matter.pb0_5.{sensor}',
                 value_converter: null,
-                units: {default: 'ppd', units_field: null, units_template: '{value}'}
+                units: { default: 'ppd', units_field: null, units_template: '{value}' }
             },
         ],
         'PB1': [
@@ -151,7 +151,7 @@ const WiredSensorCapabilities = {
                 caption: 'PB1 ({sensor})',
                 capability: 'measure_particulate_matter.pb1.{sensor}',
                 value_converter: null,
-                units: {default: 'ppd', units_field: null, units_template: '{value}'}
+                units: { default: 'ppd', units_field: null, units_template: '{value}' }
             },
         ],
         'PB2.5': [
@@ -160,7 +160,7 @@ const WiredSensorCapabilities = {
                 caption: 'PB2.5 ({sensor})',
                 capability: 'measure_particulate_matter.pb2_5.{sensor}',
                 value_converter: null,
-                units: {default: 'ppd', units_field: null, units_template: '{value}'}
+                units: { default: 'ppd', units_field: null, units_template: '{value}' }
             },
         ],
         'PB5': [
@@ -169,7 +169,7 @@ const WiredSensorCapabilities = {
                 caption: 'PB5 ({sensor})',
                 capability: 'measure_particulate_matter.pb5.{sensor}',
                 value_converter: null,
-                units: {default: 'ppd', units_field: null, units_template: '{value}'}
+                units: { default: 'ppd', units_field: null, units_template: '{value}' }
             },
         ],
         'PB10': [
@@ -178,7 +178,7 @@ const WiredSensorCapabilities = {
                 caption: 'PB10 ({sensor})',
                 capability: 'measure_particulate_matter.pb10.{sensor}',
                 value_converter: null,
-                units: {default: 'ppd', units_field: null, units_template: '{value}'}
+                units: { default: 'ppd', units_field: null, units_template: '{value}' }
             },
         ],
         'UvLevel': [
@@ -196,7 +196,7 @@ const WiredSensorCapabilities = {
                 caption: 'Frequency ({sensor})',
                 capability: 'measure_frequency.{sensor}',
                 value_converter: null,
-                units: {default: 'Hz', units_field: null, units_template: '{value}'}
+                units: { default: 'Hz', units_field: null, units_template: '{value}' }
             },
         ],
         'Voltage': [
@@ -205,14 +205,14 @@ const WiredSensorCapabilities = {
                 caption: 'Voltage',
                 capability: 'measure_voltage',
                 value_converter: null,
-                units: {default: 'V', units_field: null, units_template: '{value}'}
+                units: { default: 'V', units_field: null, units_template: '{value}' }
             },
             {
                 sensor_filter: '*',
                 caption: 'Voltage ({sensor})',
                 capability: 'measure_voltage.{sensor}',
                 value_converter: null,
-                units: {default: 'V', units_field: null, units_template: '{value}'}
+                units: { default: 'V', units_field: null, units_template: '{value}' }
             },
         ],
         'Current': [
@@ -221,14 +221,14 @@ const WiredSensorCapabilities = {
                 caption: 'Current',
                 capability: 'measure_current',
                 value_converter: null,
-                units: {default: 'A', units_field: null, units_template: '{value}'}
+                units: { default: 'A', units_field: null, units_template: '{value}' }
             },
             {
                 sensor_filter: '*',
                 caption: 'Current ({sensor})',
                 capability: 'measure_current.{sensor}',
                 value_converter: null,
-                units: {default: 'A', units_field: null, units_template: '{value}'}
+                units: { default: 'A', units_field: null, units_template: '{value}' }
             },
         ],
         'Power': [
@@ -237,14 +237,14 @@ const WiredSensorCapabilities = {
                 caption: 'Power',
                 capability: 'measure_power',
                 value_converter: null,
-                units: {default: 'W', units_field: null, units_template: '{value}'}
+                units: { default: 'W', units_field: null, units_template: '{value}' }
             },
             {
                 sensor_filter: '*',
                 caption: 'Power ({sensor})',
                 capability: 'measure_power.{sensor}',
                 value_converter: null,
-                units: {default: 'W', units_field: null, units_template: '{value}'}
+                units: { default: 'W', units_field: null, units_template: '{value}' }
             },
         ],
         'Factor': [
@@ -269,14 +269,14 @@ const WiredSensorCapabilities = {
                 caption: 'Apparent power',
                 capability: 'measure_apparent_power',
                 value_converter: null,
-                units: {default: 'VA', units_field: null, units_template: '{value}'}
+                units: { default: 'VA', units_field: null, units_template: '{value}' }
             },
             {
                 sensor_filter: '*',
                 caption: 'Apparent power ({sensor})',
                 capability: 'measure_apparent_power.{sensor}',
                 value_converter: null,
-                units: {default: 'VA', units_field: null, units_template: '{value}'}
+                units: { default: 'VA', units_field: null, units_template: '{value}' }
             },
         ],
         'ReactivePower': [
@@ -285,14 +285,14 @@ const WiredSensorCapabilities = {
                 caption: 'Reactive power',
                 capability: 'measure_power_reactive',
                 value_converter: null,
-                units: {default: 'VAr', units_field: null, units_template: '{value}'}
+                units: { default: 'VAr', units_field: null, units_template: '{value}' }
             },
             {
                 sensor_filter: '*',
                 caption: 'Reactive power ({sensor})',
                 capability: 'measure_power_reactive.{sensor}',
                 value_converter: null,
-                units: {default: 'VAr', units_field: null, units_template: '{value}'}
+                units: { default: 'VAr', units_field: null, units_template: '{value}' }
             },
         ],
         'Total': [
@@ -301,14 +301,30 @@ const WiredSensorCapabilities = {
                 caption: 'Power meter',
                 capability: 'meter_power',
                 value_converter: null,
-                units: {default: 'kWh', units_field: null, units_template: '{value}'}
+                units: { default: 'kWh', units_field: null, units_template: '{value}' }
             },
             {
                 sensor_filter: '*',
                 caption: 'Power meter ({sensor})',
                 capability: 'meter_power.{sensor}',
                 value_converter: null,
-                units: {default: 'kWh', units_field: null, units_template: '{value}'}
+                units: { default: 'kWh', units_field: null, units_template: '{value}' }
+            },
+        ],
+        'Total_Out': [
+            {
+                sensor_filter: 'ENERGY',
+                caption: 'Power meter out',
+                capability: 'meter_power_out',
+                value_converter: null,
+                units: { default: 'kWh', units_field: null, units_template: '{value}' }
+            },
+            {
+                sensor_filter: '*',
+                caption: 'Power meter out ({sensor})',
+                capability: 'meter_power_out.{sensor}',
+                value_converter: null,
+                units: { default: 'kWh', units_field: null, units_template: '{value}' }
             },
         ],
         'Today': [
@@ -317,14 +333,14 @@ const WiredSensorCapabilities = {
                 caption: 'Power meter today',
                 capability: 'meter_energy_today',
                 value_converter: null,
-                units: {default: 'kWh', units_field: null, units_template: '{value}'}
+                units: { default: 'kWh', units_field: null, units_template: '{value}' }
             },
             {
                 sensor_filter: '*',
                 caption: 'Power meter today ({sensor})',
                 capability: 'meter_energy_today.{sensor}',
                 value_converter: null,
-                units: {default: 'kWh', units_field: null, units_template: '{value}'}
+                units: { default: 'kWh', units_field: null, units_template: '{value}' }
             },
         ],
         'Yesterday': [
@@ -333,14 +349,14 @@ const WiredSensorCapabilities = {
                 caption: 'Power meter yesterday',
                 capability: 'meter_energy_yesterday',
                 value_converter: null,
-                units: {default: 'kWh', units_field: null, units_template: '{value}'}
+                units: { default: 'kWh', units_field: null, units_template: '{value}' }
             },
             {
                 sensor_filter: '*',
                 caption: 'Power meter yesterday ({sensor})',
                 capability: 'meter_energy_yesterday.{sensor}',
                 value_converter: null,
-                units: {default: 'kWh', units_field: null, units_template: '{value}'}
+                units: { default: 'kWh', units_field: null, units_template: '{value}' }
             },
         ],
         'SeaPressure': [
@@ -349,7 +365,7 @@ const WiredSensorCapabilities = {
                 caption: 'Sea level pressure ({sensor})',
                 capability: 'measure_pressure.see_level.{sensor}',
                 value_converter: null,
-                units: {default: 'hPa', units_field: 'PressureUnit', units_template: '{value}'}
+                units: { default: 'hPa', units_field: 'PressureUnit', units_template: '{value}' }
             },
         ],
         'TVOC': [
@@ -358,7 +374,7 @@ const WiredSensorCapabilities = {
                 caption: 'TVOC ({sensor})',
                 capability: 'measure_tvoc.{sensor}',
                 value_converter: null,
-                units: {default: 'ppb', units_field: null, units_template: '{value}'}
+                units: { default: 'ppb', units_field: null, units_template: '{value}' }
             },
         ],
         'eCO2': [
@@ -367,7 +383,7 @@ const WiredSensorCapabilities = {
                 caption: 'Equivalent CO\u2082 ({sensor})',
                 capability: 'measure_co2.eco2.{sensor}',
                 value_converter: null,
-                units: {default: 'ppm', units_field: null, units_template: '{value}'}
+                units: { default: 'ppm', units_field: null, units_template: '{value}' }
             },
         ],
         'A': [
@@ -403,7 +419,7 @@ const WiredSensorCapabilities = {
                 caption: 'MQ2_0 ({sensor})',
                 capability: 'measure_MQ2_0.{sensor}',
                 value_converter: null,
-                units: {default: 'ppm', units_field: null, units_template: '{value}'}
+                units: { default: 'ppm', units_field: null, units_template: '{value}' }
             },
         ],
     },
@@ -423,13 +439,13 @@ const ZigbeeSensorCapabilities = {
             },
         ],
         'Humidity': [
-            {sensor_filter: '*', caption: null, capability: 'measure_humidity', value_converter: null, units: null},
+            { sensor_filter: '*', caption: null, capability: 'measure_humidity', value_converter: null, units: null },
         ],
         'Pressure': [
-            {sensor_filter: '*', caption: null, capability: 'measure_pressure', value_converter: null, units: null},
+            { sensor_filter: '*', caption: null, capability: 'measure_pressure', value_converter: null, units: null },
         ],
         'BatteryPercentage': [
-            {sensor_filter: '*', caption: null, capability: 'measure_battery', value_converter: null, units: null},
+            { sensor_filter: '*', caption: null, capability: 'measure_battery', value_converter: null, units: null },
         ],
         'LinkQuality': [
             {
@@ -451,7 +467,7 @@ const ZigbeeSensorCapabilities = {
             },
         ],
         'Illuminance': [
-            {sensor_filter: '*', caption: null, capability: 'measure_luminance', value_converter: null, units: null},
+            { sensor_filter: '*', caption: null, capability: 'measure_luminance', value_converter: null, units: null },
         ],
         'Occupancy': [
             {
@@ -501,7 +517,7 @@ const forEachSensorValue = (root, lambda, debug) => {
                 }
             });
         } catch (error) {
-            if (debug) throw(error);
+            if (debug) throw (error);
         }
 
     }
@@ -523,7 +539,7 @@ const getCapabilitiesObjectByType = (capType) => {
 const parseSensorValueName = (stringName) => {
     let regExpRes = sensorNameRegExp.exec(stringName);
     if (regExpRes !== null) {
-        return {name: regExpRes.groups.name, index: regExpRes.groups.index};
+        return { name: regExpRes.groups.name, index: regExpRes.groups.index };
     } else
         return null;
 }


### PR DESCRIPTION
My smartmeter also provides a total of what was going out of my home network. Addition to see it under capabilities, I like to have it also available in insights in order to keep an eye on it. 

![image](https://github.com/spkesDE/com.paveld.tasmota/assets/1651782/89e9495f-584d-4add-b2da-79775d769228)
 